### PR TITLE
Add icon name to className attribute

### DIFF
--- a/packages/react/src/createMaterialIcon.ts
+++ b/packages/react/src/createMaterialIcon.ts
@@ -25,7 +25,7 @@ export default function createMaterialIcon(
       const svgFill = fill ?? 'none';
       const pathFill = fill ? undefined : 'currentColor';
 
-      const combinedClassName = ['material-symbols', className].filter(Boolean).join(' ');
+      const combinedClassName = ['material-symbols', `material-symbols_${iconName}`, className].filter(Boolean).join(' ');
 
       return createElement(
         'svg',


### PR DESCRIPTION
## Summary
- アイコン名をクラス名に追加（例：material-symbols_home）
- CSSセレクタでアイコン別のスタイリングが可能になる

## Changes
- `createMaterialIcon.ts`: combinedClassNameにアイコン名を含める機能を追加

## Test plan
- [ ] 開発ビルドでアイコンコンポーネントにクラス名が正しく追加されることを確認
- [ ] 既存の機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)