### PR TITLE
[codex] remove package readme sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - コードコメントは英語
 - TypeScriptは明示的な型を優先（`noImplicitAny: true`）
 - スクリプトは ESM 前提（`type: module` / `moduleResolution: NodeNext`）
+- github連携はghコマンドを利用
 
 ## プロジェクト概要
 

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -182,33 +182,6 @@ import * as Icons from '@material-symbols-svg/astro/w400';
 ---
 ```
 
-## Available Icons
-
-This package includes 3,836+ Material Symbols icons across outlined, rounded, and sharp styles. All icons are available in multiple categories:
-
-- **Action** - Common UI actions
-- **Alert** - Notifications and warnings
-- **AV** - Audio/video controls
-- **Communication** - Chat, email, phone
-- **Content** - Text editing, formatting
-- **Device** - Hardware and device icons
-- **Editor** - Text and content editing
-- **File** - File operations and types
-- **Hardware** - Computer and device hardware
-- **Home** - Smart home and IoT
-- **Image** - Photo and image editing
-- **Maps** - Location and navigation
-- **Navigation** - App navigation elements
-- **Notification** - System notifications
-- **Places** - Locations and buildings
-- **Search** - Search and discovery
-- **Social** - Social media and sharing
-- **Toggle** - On/off and selection controls
-
-## Contributing
-
-See the main repository for contribution guidelines: [material-symbols-svg](https://github.com/k-s-h-r/material-symbols-svg)
-
 ## License
 
 This project is licensed under the Apache-2.0 License. See the [LICENSE](../../LICENSE) file for details.

--- a/packages/metadata/README.md
+++ b/packages/metadata/README.md
@@ -89,14 +89,6 @@ type IconPathData = {
 }
 ```
 
-## Available Icons
-
-This package contains metadata for **3,836 unique icons** across:
-
-- **3 styles**: outlined, rounded, sharp
-- **7 weights**: 100, 200, 300, 400, 500, 600, 700
-- **Categories**: action, navigation, social, toggle, and more
-
 ## Companion Packages
 
 - [`@material-symbols-svg/react`](https://www.npmjs.com/package/@material-symbols-svg/react) - React components (Outlined / Rounded / Sharp)

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -169,33 +169,6 @@ import * as Icons from '@material-symbols-svg/react-native/w400';
 
 React Native bundlers do not have a universal package import optimization flag like Next.js. Prefer explicit subpath imports such as `/w400` and `/icons/home`, then verify the production bundle output in your app.
 
-## Available Icons
-
-This package includes 3,836+ Material Symbols icons across outlined, rounded, and sharp styles. All icons are available in multiple categories:
-
-- **Action** - Common UI actions
-- **Alert** - Notifications and warnings
-- **AV** - Audio/video controls
-- **Communication** - Chat, email, phone
-- **Content** - Text editing, formatting
-- **Device** - Hardware and device icons
-- **Editor** - Text and content editing
-- **File** - File operations and types
-- **Hardware** - Computer and device hardware
-- **Home** - Smart home and IoT
-- **Image** - Photo and image editing
-- **Maps** - Location and navigation
-- **Navigation** - App navigation elements
-- **Notification** - System notifications
-- **Places** - Locations and buildings
-- **Search** - Search and discovery
-- **Social** - Social media and sharing
-- **Toggle** - On/off and selection controls
-
-## Contributing
-
-See the main repository for contribution guidelines: [material-symbols-svg](https://github.com/k-s-h-r/material-symbols-svg)
-
 ## License
 
 This project is licensed under the Apache-2.0 License. See the [LICENSE](../../LICENSE) file for details.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -213,33 +213,6 @@ const nextConfig = {
 export default nextConfig;
 ```
 
-## Available Icons
-
-This package includes 3,836+ Material Symbols icons across outlined, rounded, and sharp styles. All icons are available in multiple categories:
-
-- **Action** - Common UI actions
-- **Alert** - Notifications and warnings  
-- **AV** - Audio/video controls
-- **Communication** - Chat, email, phone
-- **Content** - Text editing, formatting
-- **Device** - Hardware and device icons
-- **Editor** - Text and content editing
-- **File** - File operations and types
-- **Hardware** - Computer and device hardware
-- **Home** - Smart home and IoT
-- **Image** - Photo and image editing
-- **Maps** - Location and navigation
-- **Navigation** - App navigation elements
-- **Notification** - System notifications
-- **Places** - Locations and buildings
-- **Search** - Search and discovery
-- **Social** - Social media and sharing
-- **Toggle** - On/off and selection controls
-
-## Contributing
-
-See the main repository for contribution guidelines: [material-symbols-svg](https://github.com/k-s-h-r/material-symbols-svg)
-
 ## License
 
 This project is licensed under the Apache-2.0 License. See the [LICENSE](../../LICENSE) file for details.

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -182,33 +182,6 @@ Framework checks against a local Svelte 5 + Vite app showed that `icons/*` deep 
 </script>
 ```
 
-## Available Icons
-
-This package includes 3,836+ Material Symbols icons across outlined, rounded, and sharp styles. All icons are available in multiple categories:
-
-- **Action** - Common UI actions
-- **Alert** - Notifications and warnings
-- **AV** - Audio/video controls
-- **Communication** - Chat, email, phone
-- **Content** - Text editing, formatting
-- **Device** - Hardware and device icons
-- **Editor** - Text and content editing
-- **File** - File operations and types
-- **Hardware** - Computer and device hardware
-- **Home** - Smart home and IoT
-- **Image** - Photo and image editing
-- **Maps** - Location and navigation
-- **Navigation** - App navigation elements
-- **Notification** - System notifications
-- **Places** - Locations and buildings
-- **Search** - Search and discovery
-- **Social** - Social media and sharing
-- **Toggle** - On/off and selection controls
-
-## Contributing
-
-See the main repository for contribution guidelines: [material-symbols-svg](https://github.com/k-s-h-r/material-symbols-svg)
-
 ## License
 
 This project is licensed under the Apache-2.0 License. See the [LICENSE](../../LICENSE) file for details.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -181,33 +181,6 @@ import * as Icons from '@material-symbols-svg/vue/w400';
 </script>
 ```
 
-## Available Icons
-
-This package includes 3,836+ Material Symbols icons across outlined, rounded, and sharp styles. All icons are available in multiple categories:
-
-- **Action** - Common UI actions
-- **Alert** - Notifications and warnings  
-- **AV** - Audio/video controls
-- **Communication** - Chat, email, phone
-- **Content** - Text editing, formatting
-- **Device** - Hardware and device icons
-- **Editor** - Text and content editing
-- **File** - File operations and types
-- **Hardware** - Computer and device hardware
-- **Home** - Smart home and IoT
-- **Image** - Photo and image editing
-- **Maps** - Location and navigation
-- **Navigation** - App navigation elements
-- **Notification** - System notifications
-- **Places** - Locations and buildings
-- **Search** - Search and discovery
-- **Social** - Social media and sharing
-- **Toggle** - On/off and selection controls
-
-## Contributing
-
-See the main repository for contribution guidelines: [material-symbols-svg](https://github.com/k-s-h-r/material-symbols-svg)
-
 ## License
 
 This project is licensed under the Apache-2.0 License. See the [LICENSE](../../LICENSE) file for details.


### PR DESCRIPTION
## Summary
- remove the `Available Icons` section from published package READMEs
- remove the `Contributing` section from published framework package READMEs
- include the AGENTS.md update that directs GitHub integration through `gh`

## Testing
- not run (documentation-only changes)