### PR TITLE
[codex] keep removed icons as empty components

### DIFF
--- a/scripts/generate-icons.ts
+++ b/scripts/generate-icons.ts
@@ -16,7 +16,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { arePathsIdentical, getIconPaths, toPascalCase } from './templates/common.ts';
+import { arePathsIdentical, createEmptyIconPaths, getIconPaths, toPascalCase } from './templates/common.ts';
 import { dirnameFromImportMeta } from './utils/module-path.ts';
 
 type FrameworkTemplate = {
@@ -52,6 +52,7 @@ type IconIndexEntry = {
   name: string;
   iconName: string;
   categories: string[];
+  removed?: boolean;
 };
 
 type IconIndex = Record<string, IconIndexEntry>;
@@ -201,7 +202,7 @@ async function processStyle(
 
   // Load icon list from icon-catalog.json
   const iconCatalogPath = path.join(SCRIPT_DIR, '../metadata/icon-catalog.json');
-  const iconIndex = JSON.parse(fs.readFileSync(iconCatalogPath, 'utf8')) as Record<string, unknown>;
+  const iconIndex = JSON.parse(fs.readFileSync(iconCatalogPath, 'utf8')) as IconIndex;
   const uniqueIconNames = Object.keys(iconIndex);
   
   // 開発時制限（環境変数で制御）
@@ -223,8 +224,12 @@ async function processStyle(
   }
   
   for (const iconName of iconNames) {
-    const paths = getIconPaths(iconName, style);
-    if (!Object.keys(paths.regular).length) continue; // Skip if no regular paths found
+    const catalogEntry = iconIndex[iconName];
+    const isRemoved = catalogEntry?.removed === true;
+    const iconPaths = getIconPaths(iconName, style);
+    const hasRegularPaths = Object.keys(iconPaths.regular).length > 0;
+    if (!hasRegularPaths && !isRemoved) continue; // Skip if no regular paths found
+    const paths = hasRegularPaths ? iconPaths : createEmptyIconPaths(iconName);
 
     const kebabCaseName = iconName.replace(/_/g, '-');
     // For package files: only include fill data if it's different from regular

--- a/scripts/generate-metadata.ts
+++ b/scripts/generate-metadata.ts
@@ -17,13 +17,15 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { getIconPaths, toPascalCase } from './templates/common.ts';
+import { createEmptyIconPaths, getIconPaths, toPascalCase } from './templates/common.ts';
 import { dirnameFromImportMeta } from './utils/module-path.ts';
 
 type SearchTermsData = Record<string, string[]>;
 
 type CatalogEntry = {
   categories?: string[];
+  removed?: boolean;
+  removedVersion?: string;
 };
 
 type CatalogIndex = Record<string, CatalogEntry>;
@@ -33,6 +35,8 @@ type GeneratedIconIndexEntry = {
   iconName: string;
   categories: string[];
   searchTerms?: string[];
+  removed?: boolean;
+  removedVersion?: string;
 };
 
 type GeneratedIconIndex = Record<string, GeneratedIconIndexEntry>;
@@ -83,12 +87,16 @@ function generateConsolidatedMetadata() {
   const validIconNames = [];
   
   for (const iconName of iconNames) {
+    const catalogEntry = iconIndex[iconName] as CatalogEntry | undefined;
+    const isRemoved = catalogEntry?.removed === true;
     const iconData: IconMetadataPathFile = {};
     let hasValidPaths = false;
     
     for (const style of STYLES) {
-      const paths = getIconPaths(iconName, style);
-      if (!Object.keys(paths.regular).length) continue; // Skip if no regular paths found
+      const iconPaths = getIconPaths(iconName, style);
+      const hasRegularPaths = Object.keys(iconPaths.regular).length > 0;
+      if (!hasRegularPaths && !isRemoved) continue; // Skip if no regular paths found
+      const paths = hasRegularPaths ? iconPaths : createEmptyIconPaths(iconName);
       
       hasValidPaths = true;
       iconData[style] = {
@@ -195,7 +203,9 @@ function generateGlobalIconIndex(validIconNames: string[] | null = null) {
       name: iconName,          // 元のアイコン名
       iconName: componentName, // Reactコンポーネント名
       categories: getIconCategories(iconName), // カテゴリ情報（配列）
-      ...(searchTerms.length > 0 && { searchTerms }) // 検索ワード（存在する場合のみ）
+      ...(searchTerms.length > 0 && { searchTerms }), // 検索ワード（存在する場合のみ）
+      ...(existingIconIndex[iconName]?.removed ? { removed: true } : {}),
+      ...(existingIconIndex[iconName]?.removedVersion ? { removedVersion: existingIconIndex[iconName].removedVersion } : {}),
     };
   }
   

--- a/scripts/templates/common.ts
+++ b/scripts/templates/common.ts
@@ -19,6 +19,7 @@ export type IconPathsResult = {
   hasFilledVariant: boolean;
   hasActualFilledFile: boolean;
   name?: string;
+  removed?: boolean;
 };
 
 type IconMetadata = {
@@ -102,7 +103,34 @@ export function getIconPaths(iconName: string, style: string): IconPathsResult {
       hasFilledVariant = true; // Material Symbols conceptually always has fill variants
     }
   }
-  return { ...paths, previews, hasFilledVariant, hasActualFilledFile };
+  return { ...paths, previews, hasFilledVariant, hasActualFilledFile, name: iconName };
+}
+
+export function createEmptyIconPaths(iconName: string): IconPathsResult {
+  const regular = {} as WeightPathMap;
+  const filled = {} as WeightPathMap;
+  const regularPreviews = {} as WeightPathMap;
+  const filledPreviews = {} as WeightPathMap;
+
+  for (const weight of WEIGHTS) {
+    regular[weight] = '';
+    filled[weight] = '';
+    regularPreviews[weight] = '';
+    filledPreviews[weight] = '';
+  }
+
+  return {
+    regular,
+    filled,
+    previews: {
+      regular: regularPreviews,
+      filled: filledPreviews,
+    },
+    hasFilledVariant: true,
+    hasActualFilledFile: false,
+    name: iconName,
+    removed: true,
+  };
 }
 
 /**
@@ -161,7 +189,8 @@ const pathData = {\n  regular: ${JSON.stringify(paths.regular, null, 2)}`;
 
   const metadataString = `const metadata = ${JSON.stringify({
     ...metadata,
-    hasFilledVariant: paths.hasFilledVariant
+    hasFilledVariant: paths.hasFilledVariant,
+    ...(paths.removed ? { removed: true } : {})
   }, null, 2)};\n\n`;
 
   return { pathDataString, metadataString };

--- a/scripts/update-metadata.ts
+++ b/scripts/update-metadata.ts
@@ -85,6 +85,8 @@ type IconCatalogEntry = {
   iconName: string;
   categories: string[];
   version: string | null;
+  removed?: boolean;
+  removedVersion?: string;
 };
 
 type IconCatalog = Record<string, IconCatalogEntry>;
@@ -362,6 +364,31 @@ function buildDiffIndexFromVersions(versions: VersionMap): DiffIndex {
     diffIndex[iconName] = { version };
   }
   return diffIndex;
+}
+
+function toComponentName(iconName: string): string {
+  return iconName
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('');
+}
+
+function buildRemovedIconEntry(
+  iconName: string,
+  oldIconIndex: Record<string, Partial<IconCatalogEntry>>,
+  removedVersion: string,
+): IconCatalogEntry {
+  const oldEntry = oldIconIndex[iconName] || {};
+  const categories = Array.isArray(oldEntry.categories) ? oldEntry.categories : ['uncategorized'];
+
+  return {
+    name: iconName,
+    iconName: typeof oldEntry.iconName === 'string' ? oldEntry.iconName : toComponentName(iconName),
+    categories,
+    version: null,
+    removed: true,
+    removedVersion,
+  };
 }
 
 /**
@@ -657,15 +684,9 @@ async function updateMetadata() {
         categories = oldIconIndex[iconName].categories;
       }
 
-      // コンポーネント名を生成 (Pascal Case)
-      const componentName = iconName
-        .split('_')
-        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-        .join('');
-
       newIconIndex[iconName] = {
         name: iconName,
-        iconName: componentName,
+        iconName: toComponentName(iconName),
         categories: categories,
         version: alignedToVersions[iconName]
       };
@@ -676,6 +697,25 @@ async function updateMetadata() {
       buildDiffIndexFromVersions(alignedFromVersions),
       buildDiffIndexFromVersions(alignedToVersions),
     );
+
+    for (const iconName of changes.removed) {
+      newIconIndex[iconName] = buildRemovedIconEntry(iconName, oldIconIndex, toVersion);
+    }
+
+    for (const [iconName, oldEntry] of Object.entries(oldIconIndex)) {
+      if (newIconIndex[iconName]) {
+        continue;
+      }
+      if (oldEntry.removed !== true) {
+        continue;
+      }
+
+      newIconIndex[iconName] = buildRemovedIconEntry(
+        iconName,
+        oldIconIndex,
+        typeof oldEntry.removedVersion === 'string' ? oldEntry.removedVersion : toVersion,
+      );
+    }
 
     // メタデータディレクトリを作成（存在しない場合）
     await mkdir(path.join(SCRIPT_DIR, '../metadata'), { recursive: true });


### PR DESCRIPTION
## Summary

- Keep icons that disappear from upstream as empty compatibility component exports.
- Store removed icons separately in metadata/removed-icons.json and packages/metadata/removed-icons.json.
- Keep metadata/icon-catalog.json and packages/metadata/icon-index.json limited to current upstream icons.
- Update to @material-symbols/svg-* 0.45.1 and prepare the 0.8.0 release files.

## Why

When upstream Material Symbols removes an icon, consumers that still import that icon currently hit build-time errors because generated exports disappear. The SVG path cannot be recovered after removal, so the compatibility behavior is to keep the original component export as an empty icon.

Removed icons are kept out of icon-index.json so icon counts and current-icon metadata remain easy to validate. The separate removed-icons.json file tracks compatibility-only exports.

## Validation

- pnpm run update:icons:auto
- pnpm run build:metadata
- pnpm i --lockfile-only --no-frozen-lockfile
- pnpm run release:prepare -- --type=auto
- pnpm exec tsc --noEmit
- pnpm run lint

## Metadata check

- packages/metadata/icon-index.json: 3885 icons
- packages/metadata/removed-icons.json: 3 icons (bitbucket, gitlab, unknown_7)
- icon-index entries with removed metadata: 0