### PR TITLE
[codex] document removed icon declarations

### DIFF
--- a/scripts/templates/astro-template.ts
+++ b/scripts/templates/astro-template.ts
@@ -1,4 +1,4 @@
-import { WEIGHTS, generatePathDataString, toPascalCase, type IconPathsResult } from './common.ts';
+import { WEIGHTS, generatePathDataString, generateRemovedIconJSDoc, toPascalCase, type IconPathsResult } from './common.ts';
 
 type TemplateOptions = {
   createIconPath?: string;
@@ -17,10 +17,11 @@ export function generateIconFileContent(
   const createIconPath = options.createIconPath || '../createMaterialIcon';
   const typeExportPath = options.typeExportPath || '../types';
   const { pathDataString, metadataString } = generatePathDataString(componentName, style, paths, isIdentical);
+  const removedIconJSDoc = generateRemovedIconJSDoc(paths);
 
   const regularExports = WEIGHTS.map((weight) => `/**
  * ${componentName} (Weight: ${weight}) - ${style.charAt(0).toUpperCase() + style.slice(1)} style
- * @preview ![img](data:image/svg+xml;base64,${paths.previews.regular[weight]})
+${removedIconJSDoc} * @preview ![img](data:image/svg+xml;base64,${paths.previews.regular[weight]})
  */
 export const ${componentName}W${weight} = /*#__PURE__*/ createMaterialIcon('${iconName}', pathData.regular[${weight}]);`).join('\n\n');
   const filledExports = WEIGHTS.map((weight) => {
@@ -28,7 +29,7 @@ export const ${componentName}W${weight} = /*#__PURE__*/ createMaterialIcon('${ic
     const previewKey = isIdentical ? 'regular' : 'filled';
     return `/**
  * ${filledComponentName} (Weight: ${weight}) - ${style.charAt(0).toUpperCase() + style.slice(1)} style (Filled)
- * @preview ![img](data:image/svg+xml;base64,${paths.previews[previewKey][weight]})
+${removedIconJSDoc} * @preview ![img](data:image/svg+xml;base64,${paths.previews[previewKey][weight]})
  */
 export const ${filledComponentName}W${weight} = /*#__PURE__*/ createMaterialIcon('${iconName}', pathData.${dataKey}[${weight}]);`;
   }).join('\n\n');

--- a/scripts/templates/common.ts
+++ b/scripts/templates/common.ts
@@ -145,6 +145,16 @@ export function arePathsIdentical(paths: IconPathsResult): boolean {
   return true;
 }
 
+export function generateRemovedIconJSDoc(paths: IconPathsResult): string {
+  if (!paths.removed) {
+    return '';
+  }
+
+  return ` * This icon was removed from upstream Material Symbols and renders empty path data for compatibility.
+ * @removed
+`;
+}
+
 /**
  * Generate common metadata for an icon
  */

--- a/scripts/templates/react-native-template.ts
+++ b/scripts/templates/react-native-template.ts
@@ -1,4 +1,4 @@
-import { WEIGHTS, generatePathDataString, toPascalCase, type IconPathsResult } from './common.ts';
+import { WEIGHTS, generatePathDataString, generateRemovedIconJSDoc, toPascalCase, type IconPathsResult } from './common.ts';
 
 const CREATE_ICON_PATH = '../createMaterialIcon';
 
@@ -23,11 +23,12 @@ export function generateIconFileContent(
   const typeExportPath = options.typeExportPath || createIconPath;
 
   const { pathDataString, metadataString } = generatePathDataString(componentName, style, paths, isIdentical);
+  const removedIconJSDoc = generateRemovedIconJSDoc(paths);
 
   const regularExports = WEIGHTS.map(w =>
     `/**
  * ${componentName} (Weight: ${w}) - ${style.charAt(0).toUpperCase() + style.slice(1)} style
- * @preview ![img](data:image/svg+xml;base64,${paths.previews.regular[w]})
+${removedIconJSDoc} * @preview ![img](data:image/svg+xml;base64,${paths.previews.regular[w]})
  */
 export const ${componentName}W${w} = /*#__PURE__*/ createMaterialIcon('${iconName}', pathData.regular[${w}]);`
   ).join('\n\n');
@@ -37,7 +38,7 @@ export const ${componentName}W${w} = /*#__PURE__*/ createMaterialIcon('${iconNam
     const previewKey = isIdentical ? 'regular' : 'filled';
     return `/**
  * ${filledComponentName} (Weight: ${w}) - ${style.charAt(0).toUpperCase() + style.slice(1)} style (Filled)
- * @preview ![img](data:image/svg+xml;base64,${paths.previews[previewKey][w]})
+${removedIconJSDoc} * @preview ![img](data:image/svg+xml;base64,${paths.previews[previewKey][w]})
  */
 export const ${filledComponentName}W${w} = /*#__PURE__*/ createMaterialIcon('${iconName}', pathData.${dataKey}[${w}]);`;
   }).join('\n\n');

--- a/scripts/templates/react-template.ts
+++ b/scripts/templates/react-template.ts
@@ -1,4 +1,4 @@
-import { WEIGHTS, generatePathDataString, toPascalCase, type IconPathsResult } from './common.ts';
+import { WEIGHTS, generatePathDataString, generateRemovedIconJSDoc, toPascalCase, type IconPathsResult } from './common.ts';
 
 const CREATE_ICON_PATH = '../createMaterialIcon';
 
@@ -23,11 +23,12 @@ export function generateIconFileContent(
   const typeExportPath = options.typeExportPath || createIconPath;
 
   const { pathDataString, metadataString } = generatePathDataString(componentName, style, paths, isIdentical);
+  const removedIconJSDoc = generateRemovedIconJSDoc(paths);
 
   const regularExports = WEIGHTS.map(w => 
     `/**
  * ${componentName} (Weight: ${w}) - ${style.charAt(0).toUpperCase() + style.slice(1)} style
- * @preview ![img](data:image/svg+xml;base64,${paths.previews.regular[w]})
+${removedIconJSDoc} * @preview ![img](data:image/svg+xml;base64,${paths.previews.regular[w]})
  */
 export const ${componentName}W${w} = /*#__PURE__*/ createMaterialIcon('${iconName}', pathData.regular[${w}]);`
   ).join('\n\n');
@@ -37,7 +38,7 @@ export const ${componentName}W${w} = /*#__PURE__*/ createMaterialIcon('${iconNam
     const previewKey = isIdentical ? 'regular' : 'filled';
     return `/**
  * ${filledComponentName} (Weight: ${w}) - ${style.charAt(0).toUpperCase() + style.slice(1)} style (Filled)
- * @preview ![img](data:image/svg+xml;base64,${paths.previews[previewKey][w]})
+${removedIconJSDoc} * @preview ![img](data:image/svg+xml;base64,${paths.previews[previewKey][w]})
  */
 export const ${filledComponentName}W${w} = /*#__PURE__*/ createMaterialIcon('${iconName}', pathData.${dataKey}[${w}]);`;
   }).join('\n\n');

--- a/scripts/templates/svelte-template.ts
+++ b/scripts/templates/svelte-template.ts
@@ -1,4 +1,4 @@
-import { WEIGHTS, generatePathDataString, toPascalCase, type IconPathsResult } from './common.ts';
+import { WEIGHTS, generatePathDataString, generateRemovedIconJSDoc, toPascalCase, type IconPathsResult } from './common.ts';
 
 const CREATE_ICON_PATH = '../createMaterialIcon';
 
@@ -27,10 +27,11 @@ export function generateIconFileContent(
   const typeExportPath = ensureJsExtension(options.typeExportPath || '../types');
 
   const { pathDataString, metadataString } = generatePathDataString(componentName, style, paths, isIdentical);
+  const removedIconJSDoc = generateRemovedIconJSDoc(paths);
 
   const regularExports = WEIGHTS.map((weight) => `/**
  * ${componentName} (Weight: ${weight}) - ${style.charAt(0).toUpperCase() + style.slice(1)} style
- * @preview ![img](data:image/svg+xml;base64,${paths.previews.regular[weight]})
+${removedIconJSDoc} * @preview ![img](data:image/svg+xml;base64,${paths.previews.regular[weight]})
  */
 export const ${componentName}W${weight} = /*#__PURE__*/ createMaterialIcon('${iconName}', pathData.regular[${weight}]);`).join('\n\n');
 
@@ -39,7 +40,7 @@ export const ${componentName}W${weight} = /*#__PURE__*/ createMaterialIcon('${ic
     const previewKey = isIdentical ? 'regular' : 'filled';
     return `/**
  * ${filledComponentName} (Weight: ${weight}) - ${style.charAt(0).toUpperCase() + style.slice(1)} style (Filled)
- * @preview ![img](data:image/svg+xml;base64,${paths.previews[previewKey][weight]})
+${removedIconJSDoc} * @preview ![img](data:image/svg+xml;base64,${paths.previews[previewKey][weight]})
  */
 export const ${filledComponentName}W${weight} = /*#__PURE__*/ createMaterialIcon('${iconName}', pathData.${dataKey}[${weight}]);`;
   }).join('\n\n');

--- a/scripts/templates/vue-template.ts
+++ b/scripts/templates/vue-template.ts
@@ -1,4 +1,4 @@
-import { WEIGHTS, generatePathDataString, toPascalCase, type IconPathsResult } from './common.ts';
+import { WEIGHTS, generatePathDataString, generateRemovedIconJSDoc, toPascalCase, type IconPathsResult } from './common.ts';
 
 const CREATE_ICON_PATH = '../createMaterialIcon';
 
@@ -22,11 +22,12 @@ export function generateIconFileContent(
   const createIconPath = options.createIconPath || CREATE_ICON_PATH;
 
   const { pathDataString, metadataString } = generatePathDataString(componentName, style, paths, isIdentical);
+  const removedIconJSDoc = generateRemovedIconJSDoc(paths);
 
   const regularExports = WEIGHTS.map(w => 
     `/**
  * ${componentName} (Weight: ${w}) - ${style.charAt(0).toUpperCase() + style.slice(1)} style
- * @preview ![img](data:image/svg+xml;base64,${paths.previews.regular[w]})
+${removedIconJSDoc} * @preview ![img](data:image/svg+xml;base64,${paths.previews.regular[w]})
  */
 export const ${componentName}W${w} = /*#__PURE__*/ createMaterialIcon('${iconName}', pathData.regular[${w}]);`
   ).join('\n\n');
@@ -36,7 +37,7 @@ export const ${componentName}W${w} = /*#__PURE__*/ createMaterialIcon('${iconNam
     const previewKey = isIdentical ? 'regular' : 'filled';
     return `/**
  * ${filledComponentName} (Weight: ${w}) - ${style.charAt(0).toUpperCase() + style.slice(1)} style (Filled)
- * @preview ![img](data:image/svg+xml;base64,${paths.previews[previewKey][w]})
+${removedIconJSDoc} * @preview ![img](data:image/svg+xml;base64,${paths.previews[previewKey][w]})
  */
 export const ${filledComponentName}W${w} = /*#__PURE__*/ createMaterialIcon('${iconName}', pathData.${dataKey}[${w}]);`;
   }).join('\n\n');


### PR DESCRIPTION
## Summary

- Add removed-icon JSDoc text to generated icon exports across React, Vue, React Native, Astro, and Svelte templates.
- Include an @removed tag when generated path data comes from removed-icons.json.
- Keep normal icon comments unchanged.

## Why

Removed icons intentionally render empty path data for compatibility. The generated declarations should make that clear in editor hover text and .d.ts output.

## Validation

- pnpm exec tsx scripts/generate-icons.ts outlined react
- pnpm exec tsx scripts/generate-exports.ts outlined react
- pnpm --dir packages/react run build:types
- verified packages/react/dist/icons/bitbucket.d.ts includes the removed sentence and @removed tag
- verified all 11 removed React outlined declarations include the removed sentence and @removed tag
- pnpm exec tsc --noEmit
- pnpm run lint